### PR TITLE
fix: correct attachments set to use attachment ID instead of filename

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,14 @@ go test ./...
 - Config file at `~/.config/memos-cli/config.toml` with 0600 permissions
 - Auth priority: flags > env vars > config file
 
+## Issue Fix Workflow
+
+When fixing issues from GitHub:
+1. Create a branch for the fix (do not commit directly to main)
+2. Make changes and verify with build/vet/test
+3. Create PR on GitHub and wait for merge
+4. Do NOT push commits until PR is created and ready for review
+
 ## Key Dependencies
 
 - `github.com/spf13/cobra` — CLI framework

--- a/cmd/attachments.go
+++ b/cmd/attachments.go
@@ -21,13 +21,13 @@ func init() {
 	attachmentsCmd.AddCommand(listAttachmentsCmd)
 
 	var setAttachmentsCmd = &cobra.Command{
-		Use:   "set <memo-id> --file <path>",
+		Use:   "set <memo-id> --id <attachment-id>",
 		Short: "Set attachments for a memo (replaces all existing)",
 		Args:  cobra.ExactArgs(1),
 		RunE:  runSetAttachments,
 	}
-	setAttachmentsCmd.Flags().StringArray("file", []string{}, "File path(s) to attach")
-	setAttachmentsCmd.MarkFlagRequired("file")
+	setAttachmentsCmd.Flags().StringArray("id", []string{}, "Attachment ID(s) (format: attachments/{id})")
+	setAttachmentsCmd.MarkFlagRequired("id")
 	attachmentsCmd.AddCommand(setAttachmentsCmd)
 }
 
@@ -51,16 +51,16 @@ func runSetAttachments(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	files, _ := cmd.Flags().GetStringArray("file")
-	if len(files) == 0 {
-		cmd.Println("No files to attach")
+	ids, _ := cmd.Flags().GetStringArray("id")
+	if len(ids) == 0 {
+		cmd.Println("No attachments to set")
 		return nil
 	}
 
 	var attachments []api.Attachment
-	for _, f := range files {
+	for _, id := range ids {
 		attachments = append(attachments, api.Attachment{
-			Filename: f,
+			Name: id,
 		})
 	}
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -76,8 +76,9 @@ type Reaction struct {
 }
 
 type Attachment struct {
-	Filename string `json:"filename"`
-	Type     string `json:"type"`
+	Name     string `json:"name,omitempty"`
+	Filename string `json:"filename,omitempty"`
+	Type     string `json:"type,omitempty"`
 }
 
 type UpsertReactionRequest struct {


### PR DESCRIPTION
## Summary

Fixed the `memos attachments set` command to use attachment IDs instead of file paths.

### Problem

The `--file` flag was incorrectly passing a file path as the attachment identifier. The Memos API requires attachments to be:
1. First created via `POST /api/v1/attachments` 
2. Then associated with a memo via `PATCH /api/v1/memos/{id}/attachments` using the attachment's `name` field (format: `attachments/{id}`)

Passing a filename like `/tmp/test.txt` resulted in "invalid attachment name" error.

Fixes #1

### Solution

- Changed `--file` flag to `--id`
- Added `Name` field to `Attachment` type
- Now expects attachment IDs in format `attachments/{id}`

### Usage

```bash
# Create attachment first (via API or Memos UI)
# Then set it on a memo using its ID
memos attachments set memos/<id> --id attachments/<attachment-id>
```

### Testing

Verified with actual API calls:
- Created attachment: `attachments/a359UC9KTYgCdLqAYJRTp4`
- Set on memo: `memos attachments set memos/cPH629g8tLpBUm5gdqpAzP --id attachments/a359UC9KTYgCdLqAYJRTp4` → 200 OK
- Listed attachments successfully showed the attached file